### PR TITLE
Use SRX as reference syntax

### DIFF
--- a/acl_auditor/auditor.py
+++ b/acl_auditor/auditor.py
@@ -34,14 +34,12 @@ class DeviceFlows:
     def _create_reference_snapshot(self):
         platform = "juniper-srx"
         reference_acl = create_acl_from_yaml(flows_file, self.hostname, self.acl_name, platform)
-        print(reference_acl)
         bf_session.init_snapshot_from_text(
             reference_acl,
             platform=platform,
             snapshot_name="reference",
             overwrite=True,
         )
-        print(bfq.initIssues().answer(snapshot="reference").frame())
 
     def compare_filters(self):
         self._create_base_snapshot()

--- a/acl_auditor/auditor.py
+++ b/acl_auditor/auditor.py
@@ -32,13 +32,16 @@ class DeviceFlows:
         )
 
     def _create_reference_snapshot(self):
-        reference_acl = create_acl_from_yaml(flows_file, self.hostname, self.acl_name)
+        platform = "juniper-srx"
+        reference_acl = create_acl_from_yaml(flows_file, self.hostname, self.acl_name, platform)
+        print(reference_acl)
         bf_session.init_snapshot_from_text(
             reference_acl,
-            platform="cisco-nx",
+            platform=platform,
             snapshot_name="reference",
             overwrite=True,
         )
+        print(bfq.initIssues().answer(snapshot="reference").frame())
 
     def compare_filters(self):
         self._create_base_snapshot()

--- a/acl_auditor/helpers.py
+++ b/acl_auditor/helpers.py
@@ -12,14 +12,21 @@ def read_yaml(filename):
         return yaml.load(file, Loader=yaml.FullLoader)
 
 
-def create_acl_from_yaml(filename, hostname, filter_name):
+def create_acl_from_yaml(filename, hostname, filter_name, platform):
     reference_flows = read_yaml(filename)
-    return generate_acl_syntax(
-        reference_flows=reference_flows, hostname=hostname, filter_name=filter_name
-    )
+    if platform == "cisco-nx":
+        return generate_acl_syntax_cisco_nx(
+            reference_flows=reference_flows, hostname=hostname, filter_name=filter_name
+        )
+    elif platform == "juniper-srx":
+        return generate_acl_syntax_juniper_srx(
+            reference_flows=reference_flows, hostname=hostname, filter_name=filter_name
+        )
+    else:
+        raise ValueError("Unknown platform {}".format(platform))
 
 
-def generate_acl_syntax(reference_flows=None, hostname=None, filter_name=None):
+def generate_acl_syntax_cisco_nx(reference_flows=None, hostname=None, filter_name=None):
     """
     Turns the list of reference flows into an NXOS config file with the provided hostname and filter_name.
     """
@@ -30,6 +37,10 @@ def generate_acl_syntax(reference_flows=None, hostname=None, filter_name=None):
     seq_number = 10
 
     for flow in reference_flows:
+        dest_port = "range {}".format(" ".join(flow["dest_port"].split("-"))) if "dest_port" in flow and "-" in \
+                                                                                 flow["dest_port"] else flow.get(
+            "dest_port", "")
+
         acl_lines.append(
             "  {} {} {} {} {} {}".format(
                 seq_number,
@@ -37,9 +48,73 @@ def generate_acl_syntax(reference_flows=None, hostname=None, filter_name=None):
                 flow["proto"],
                 flow["source_ip"],
                 flow.get("dest_ip", ""),
-                flow.get("dest_port", ""),
+                dest_port,
             )
         )
         seq_number += 10
     acl_lines.append("  {} deny ip any any".format(seq_number))
     return "\n".join(acl_lines)
+
+
+def generate_acl_syntax_juniper_srx(reference_flows=None, hostname=None, filter_name=None):
+    """
+    Turns the list of reference flows into an SRX config file with the provided hostname and filter_name.
+    """
+    acl_lines = [
+        "set system host-name {}".format(hostname),
+    ]
+    term_number = 1
+
+    for flow in reference_flows:
+        acl_lines.extend(_generate_acl_term_juniper_srx(flow, filter_name, term_number))
+        term_number += 1
+
+    acl_lines.append(
+        "set firewall family inet filter {} term term{}-default-deny then discard".format(filter_name, term_number))
+    return "\n".join(acl_lines)
+
+
+def _generate_acl_term_juniper_srx(reference_flow, filter_name, term_number):
+    term_lines = []
+    term_name = reference_flow["name"] if "name" in reference_flow else _get_default_term_name(reference_flow,
+                                                                                               term_number)
+    if "source_ip" in reference_flow:
+        term_lines.append(
+            "set firewall family inet filter {} term {} from source-address {}".format(filter_name, term_name,
+                                                                                       reference_flow["source_ip"]))
+    if "dest_ip" in reference_flow:
+        term_lines.append(
+            "set firewall family inet filter {} term {} from destination-address {}".format(filter_name, term_name,
+                                                                                            reference_flow["dest_ip"]))
+
+    if "proto" in reference_flow and reference_flow["proto"] != "ip":
+        term_lines.append(
+            "set firewall family inet filter {} term {} from protocol {}".format(filter_name, term_name,
+                                                                                 reference_flow["proto"]))
+
+    if "source_port" in reference_flow:
+        term_lines.append(
+            "set firewall family inet filter {} term {} from source-port {}".format(filter_name, term_name,
+                                                                                    reference_flow["source_port"]))
+
+    if "dest_port" in reference_flow:
+        term_lines.append(
+            "set firewall family inet filter {} term {} from destination-port {}".format(filter_name, term_name,
+                                                                                         reference_flow["dest_port"]))
+
+    action = "accept" if "action" not in reference_flow or reference_flow["action"] == "permit" else "discard"
+
+    term_lines.append(
+        "set firewall family inet filter {} term {} then {}".format(filter_name, term_name, action))
+
+    return term_lines
+
+
+def _get_default_term_name(reference_flow, term_number):
+    term_name = "term{}".format(term_number)
+    if "source_ip" in reference_flow:
+        term_name = term_name + "-from-{}".format(reference_flow["source_ip"])
+    if "dest_ip" in reference_flow:
+        term_name = term_name + "-to-{}".format(reference_flow["dest_ip"])
+    # TODO: should we add more fields to the default term name?
+    return term_name

--- a/data/flows.yml
+++ b/data/flows.yml
@@ -3,12 +3,14 @@
   dest_ip: 8.8.8.8/32
   proto: ip
   action: deny
+  name: to-google-dns
 - source_ip: 11.36.216.176/32
   dest_ip: 11.36.216.0/24
   proto: ip
   action: permit
+  name: from-11-36-216-176
 - source_ip: 10.36.176.0/24
   dest_ip: 11.20.0.0/16
-  dest_port: range 1000 20000
+  dest_port: 1000-20000
   proto: tcp
   action: permit

--- a/tests/test_flows.yml
+++ b/tests/test_flows.yml
@@ -2,12 +2,14 @@
   dest_ip: 8.8.8.8/32
   proto: ip
   action: deny
+  name: to-google-dns
 - source_ip: 11.36.216.176/32
   dest_ip: 11.36.216.0/24
   proto: ip
   action: permit
+  name: from-11-36-216-176
 - source_ip: 10.36.176.0/24
   dest_ip: 11.20.0.0/16
-  dest_port: range 1000 20000
+  dest_port: 1000-20000
   proto: tcp
   action: permit

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,6 +1,6 @@
 from acl_auditor.helpers import create_acl_from_yaml, read_file, read_yaml
 
-expected_generated_acl = """hostname test-device
+expected_generated_acl_cisco_nx = """hostname test-device
 ip access-list acl-example
   10 deny ip 10.0.0.0/8 8.8.8.8/32 
   20 permit ip 11.36.216.176/32 11.36.216.0/24 
@@ -8,12 +8,35 @@ ip access-list acl-example
   40 deny ip any any"""
 
 
-def test_create_acl():
+expected_generated_acl_juniper_srx = """set system host-name test-device
+set firewall family inet filter acl-example term to-google-dns from source-address 10.0.0.0/8
+set firewall family inet filter acl-example term to-google-dns from destination-address 8.8.8.8/32
+set firewall family inet filter acl-example term to-google-dns then discard
+set firewall family inet filter acl-example term from-11-36-216-176 from source-address 11.36.216.176/32
+set firewall family inet filter acl-example term from-11-36-216-176 from destination-address 11.36.216.0/24
+set firewall family inet filter acl-example term from-11-36-216-176 then accept
+set firewall family inet filter acl-example term term3-from-10.36.176.0/24-to-11.20.0.0/16 from source-address 10.36.176.0/24
+set firewall family inet filter acl-example term term3-from-10.36.176.0/24-to-11.20.0.0/16 from destination-address 11.20.0.0/16
+set firewall family inet filter acl-example term term3-from-10.36.176.0/24-to-11.20.0.0/16 from protocol tcp
+set firewall family inet filter acl-example term term3-from-10.36.176.0/24-to-11.20.0.0/16 from destination-port 1000-20000
+set firewall family inet filter acl-example term term3-from-10.36.176.0/24-to-11.20.0.0/16 then accept
+set firewall family inet filter acl-example term term4-default-deny then discard"""
+
+
+def test_create_acl_cisco_nx():
     generated_acl = create_acl_from_yaml(
-        "tests/test_flows.yml", "test-device", "acl-example"
+        "tests/test_flows.yml", "test-device", "acl-example", "cisco-nx"
     )
     print(generated_acl)
-    assert expected_generated_acl == generated_acl
+    assert expected_generated_acl_cisco_nx == generated_acl
+
+
+def test_create_acl_juniper_srx():
+    generated_acl = create_acl_from_yaml(
+        "tests/test_flows.yml", "test-device", "acl-example", "juniper-srx"
+    )
+    print(generated_acl)
+    assert expected_generated_acl_juniper_srx == generated_acl
 
 
 def test_read_file():


### PR DESCRIPTION
How about we use SRX as reference instead of NXOS? 
 1/ SRX has richer syntax (e.g., multiple source IPs) that will enable us to expand the flow definitions if needed down the line
 2/ SRX has term names which may make for a more relatable output as flows in reference can now be named. 

For the example data, the output will have the term names (see last column)

```
  Node Filter_Name Line_Index                                     Line_Content Line_Action Reference_Line_Index                     Reference_Line_Content
0  fw1  acl-inside          0     permit udp host 10.0.2.1 host 8.8.8.8 eq ntp      PERMIT                    0                              to-google-dns
1  fw1  acl-inside          1  permit udp host 10.0.2.1 host 8.8.8.8 eq domain      PERMIT                    0                              to-google-dns
2  fw1  acl-inside          2     permit udp host 10.0.2.1 host 8.8.4.4 eq ntp      PERMIT                    3                         term4-default-deny
3  fw1  acl-inside          3  permit udp host 10.0.2.1 host 8.8.4.4 eq domain      PERMIT                    3                         term4-default-deny
4  fw1  acl-inside          4                                deny ip any4 any4        DENY                    1                         from-11-36-216-176
5  fw1  acl-inside          4                                deny ip any4 any4        DENY                    2  term3-from-10.36.176.0/24-to-11.20.0.0/16
```